### PR TITLE
fixed eiger reader to work with python3

### DIFF
--- a/chxtools/pims_readers/eiger.py
+++ b/chxtools/pims_readers/eiger.py
@@ -55,8 +55,8 @@ class EigerImages(FramesSequence):
         # Table of Contents return a tuple:
         # self._toc[5] -> [which file, which element in that file]
         self._toc = np.concatenate(
-                [zip(i*np.ones(length, dtype=int),
-                     np.arange(length, dtype=int))
+                [list(zip(i*np.ones(length, dtype=int),
+                     np.arange(length, dtype=int)))
                 for i, length in enumerate(lengths)])
 
     def get_frame(self, i):


### PR DESCRIPTION
zip in python3 now returns generator object, changed zip -> list(zip) to force a list. Checked that it works both in python 2.7 and python 3.4.
http://stackoverflow.com/questions/19777612/python-range-and-zip-object-type for more details
