### PR TITLE
added routine to read pixel mask

### DIFF
--- a/chxtools/pims_readers/eiger.py
+++ b/chxtools/pims_readers/eiger.py
@@ -110,6 +110,14 @@ class EigerImages(FramesSequence):
         f.close()
         return flatfield
 
+    def get_pixel_mask(self):
+        ''' Get the pixel mask reported by the EIGER.'''
+        f = h5py.File(self.master_filepath,"r")
+        ddetS = f['entry']['instrument']['detector']['detectorSpecific']
+        pxmsk = np.array(ddetS['pixel_mask'])
+        f.close()
+        return pxmsk
+
     def __len__(self):
         return len(self._toc)
 


### PR DESCRIPTION
I found this convenient just to grab the pixel mask.
Note that the actual mask should be 
pixelmask = (pixelmask < 1) 
after obtaining it (basically all zero pixels are pixels that should not be masked)
okay to add to chx tools?
